### PR TITLE
Add Teacher-Only Admin Mode for Activity Enrollment

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,53 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const signupLockedMessage = document.getElementById("signup-locked-message");
+
+  const userMenu = document.getElementById("user-menu");
+  const userMenuToggle = document.getElementById("user-menu-toggle");
+  const userMenuPanel = document.getElementById("user-menu-panel");
+  const authStatus = document.getElementById("auth-status");
+  const openLoginBtn = document.getElementById("open-login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginBtn = document.getElementById("close-login-btn");
+  const loginForm = document.getElementById("login-form");
+
+  let isTeacherLoggedIn = false;
+  let teacherUsername = "";
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUI() {
+    authStatus.textContent = isTeacherLoggedIn
+      ? `Logged in as ${teacherUsername}`
+      : "Not logged in";
+
+    openLoginBtn.classList.toggle("hidden", isTeacherLoggedIn);
+    logoutBtn.classList.toggle("hidden", !isTeacherLoggedIn);
+    signupForm.classList.toggle("hidden", !isTeacherLoggedIn);
+    signupLockedMessage.classList.toggle("hidden", isTeacherLoggedIn);
+  }
+
+  async function fetchAuthStatus() {
+    try {
+      const response = await fetch("/auth/status");
+      const auth = await response.json();
+      isTeacherLoggedIn = auth.is_authenticated;
+      teacherUsername = auth.username || "";
+      updateAuthUI();
+    } catch (error) {
+      console.error("Error fetching auth status:", error);
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +59,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +79,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isTeacherLoggedIn
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -86,26 +139,21 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
+
+        if (response.status === 401) {
+          isTeacherLoggedIn = false;
+          teacherUsername = "";
+          updateAuthUI();
+        }
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -130,31 +178,99 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
+
+        if (response.status === 401) {
+          isTeacherLoggedIn = false;
+          teacherUsername = "";
+          updateAuthUI();
+        }
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userMenuToggle.addEventListener("click", () => {
+    userMenuPanel.classList.toggle("hidden");
+  });
+
+  openLoginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+  });
+
+  closeLoginBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value.trim();
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      isTeacherLoggedIn = true;
+      teacherUsername = result.username;
+      updateAuthUI();
+      loginModal.classList.add("hidden");
+      userMenuPanel.classList.add("hidden");
+      loginForm.reset();
+      showMessage("Teacher login successful.", "success");
+      fetchActivities();
+    } catch (error) {
+      showMessage("Failed to log in. Please try again.", "error");
+      console.error("Error during login:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+      });
+      isTeacherLoggedIn = false;
+      teacherUsername = "";
+      updateAuthUI();
+      userMenuPanel.classList.add("hidden");
+      showMessage("Logged out.", "success");
+      fetchActivities();
+    } catch (error) {
+      showMessage("Failed to log out.", "error");
+      console.error("Error during logout:", error);
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    const clickedInsideMenu = userMenu.contains(event.target);
+    if (!clickedInsideMenu) {
+      userMenuPanel.classList.add("hidden");
+    }
+  });
+
   // Initialize app
+  fetchAuthStatus();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,14 @@
   </head>
   <body>
     <header>
+      <div class="user-menu" id="user-menu">
+        <button id="user-menu-toggle" class="icon-button" aria-label="User menu">👤</button>
+        <div id="user-menu-panel" class="user-menu-panel hidden">
+          <p id="auth-status">Not logged in</p>
+          <button id="open-login-btn" type="button">Login</button>
+          <button id="logout-btn" type="button" class="hidden">Logout</button>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -22,7 +30,10 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Register Student for an Activity</h3>
+        <p id="signup-locked-message" class="info">
+          Teachers must log in to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -44,6 +55,26 @@
     <footer>
       <p>&copy; 2023 Mergington High School</p>
     </footer>
+
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="button" id="close-login-btn">Cancel</button>
+            <button type="submit">Login</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,57 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.user-menu {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+}
+
+.icon-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid #e0e0e0;
+  background-color: #ffffff;
+  color: #1a237e;
+  cursor: pointer;
+  font-size: 18px;
+  padding: 0;
+}
+
+.icon-button:hover {
+  background-color: #f5f5f5;
+}
+
+.user-menu-panel {
+  position: absolute;
+  top: 48px;
+  right: 0;
+  width: 220px;
+  background-color: #ffffff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 12px;
+  z-index: 20;
+  text-align: left;
+}
+
+.user-menu-panel p {
+  color: #333;
+  margin-bottom: 10px;
+  font-size: 14px;
+}
+
+.user-menu-panel button {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.user-menu-panel button:last-child {
+  margin-bottom: 0;
 }
 
 main {
@@ -168,6 +220,36 @@ button:hover {
   margin-top: 20px;
   padding: 10px;
   border-radius: 4px;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 420px;
+  background-color: #ffffff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+}
+
+.modal-content h3 {
+  margin-bottom: 16px;
+  color: #1a237e;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
 }
 
 .success {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher.alex",
+      "password": "mergington123"
+    },
+    {
+      "username": "teacher.jordan",
+      "password": "clubadmin456"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add teacher login/logout/session auth endpoints
- restrict activity registration/unregistration to logged-in teachers
- add top-right user menu and login modal in UI
- keep participant lists visible to everyone
- add `src/teachers.json` for teacher credentials

## Why
Implements issue #5 to prevent students from removing each other while preserving read-only visibility for students.

## Validation
- python syntax check on `src/app.py` via `py_compile`
- editor diagnostics report no errors in changed files

Closes #5